### PR TITLE
Update MSColorSelectionView.m

### DIFF
--- a/MSColorPicker/MSColorSelectionView.m
+++ b/MSColorPicker/MSColorSelectionView.m
@@ -72,7 +72,9 @@
 - (void)setSelectedIndex:(MSSelectedColorView)index animated:(BOOL)animated
 {
     self.selectedIndex = index;
-    self.selectedView.color = self.color;
+    if (self.color != nil) {
+        self.selectedView.color = self.color;
+    }
     [UIView animateWithDuration:animated ? .5 : 0.0 animations:^{
          self.rgbColorView.alpha = index == 0 ? 1.0 : 0.0;
          self.hsbColorView.alpha = index == 1 ? 1.0 : 0.0;


### PR DESCRIPTION
* fixes crash on iPhone5 (Simulator) when MSColorSelectionViewController.color is initially set.