### PR TITLE
Dark mode support

### DIFF
--- a/MSColorPicker/MSColorSelectionView.m
+++ b/MSColorPicker/MSColorSelectionView.m
@@ -115,6 +115,12 @@
 {
     self.accessibilityLabel = @"color_selection_view";
 
+    if (@available(iOS 13.0, *)) {
+        self.backgroundColor = [UIColor systemBackgroundColor];
+    } else {
+        self.backgroundColor = [UIColor whiteColor];
+    }
+
     self.rgbColorView = [[MSRGBView alloc] init];
     self.hsbColorView = [[MSHSBView alloc] init];
     [self addColorView:self.rgbColorView];

--- a/MSColorPicker/MSColorSelectionView.m
+++ b/MSColorPicker/MSColorSelectionView.m
@@ -115,7 +115,6 @@
 {
     self.accessibilityLabel = @"color_selection_view";
 
-    self.backgroundColor = [UIColor whiteColor];
     self.rgbColorView = [[MSRGBView alloc] init];
     self.hsbColorView = [[MSHSBView alloc] init];
     [self addColorView:self.rgbColorView];


### PR DESCRIPTION
Conditionally set the MSColorSelectionView background color based on iOS version in order to set it appropriately for dark mode.